### PR TITLE
Verify service method signatures.

### DIFF
--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/ServiceMethodVisitor.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/ServiceMethodVisitor.kt
@@ -52,7 +52,8 @@ class ServiceMethodVisitor : KSEmptyVisitor<Unit, ServiceMethodDefinition>() {
                 }
                 else -> continue
             }
-            annotation.arguments.first().value.toString().takeUnless { it.isBlank() }?.let {
+
+            annotation.arguments.first().value?.toString()?.takeUnless { it.isBlank() }?.let {
                 methodName = it
             }
             break
@@ -61,8 +62,8 @@ class ServiceMethodVisitor : KSEmptyVisitor<Unit, ServiceMethodDefinition>() {
             reportError(function, "Method declarations inside @Service interfaces must provide a call type annotation.")
 
         return ServiceMethodDefinition(
-            declaredName = methodName,
-            methodName = function.simpleName.getShortName(),
+            declaredName = function.simpleName.getShortName(),
+            methodName = methodName,
             returnType = function.returnType,
             request = function.parameters.singleOrNull()
                 ?: reportError(function, "Service methods must have a single parameter."),

--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/ServiceMethodVisitor.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/ServiceMethodVisitor.kt
@@ -17,8 +17,8 @@ class ServiceMethodVisitor : KSEmptyVisitor<Unit, ServiceMethodDefinition>() {
 
     override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: Unit): ServiceMethodDefinition {
         var type: MethodDescriptor.MethodType = MethodDescriptor.MethodType.UNKNOWN
+        var methodName = function.simpleName.asString()
 
-        // TODO: Use the method name argument in the annotation
         for (annotation in function.annotations) {
             type = when (annotation.shortName.getShortName()) {
                 UnaryCall::class.simpleName -> MethodDescriptor.MethodType.UNARY
@@ -26,6 +26,9 @@ class ServiceMethodVisitor : KSEmptyVisitor<Unit, ServiceMethodDefinition>() {
                 ClientStream::class.simpleName -> MethodDescriptor.MethodType.CLIENT_STREAMING
                 BidiStream::class.simpleName -> MethodDescriptor.MethodType.BIDI_STREAMING
                 else -> continue
+            }
+            annotation.arguments.first().value.toString().takeUnless { it.isBlank() }?.let {
+                methodName = it
             }
             break
         }
@@ -35,7 +38,7 @@ class ServiceMethodVisitor : KSEmptyVisitor<Unit, ServiceMethodDefinition>() {
         }
 
         return ServiceMethodDefinition(
-            declaredName = function.simpleName.getShortName(),
+            declaredName = methodName,
             methodName = function.simpleName.getShortName(),
             returnType = function.returnType,
             request = function.parameters.singleOrNull()

--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/ServiceMethodVisitor.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/ServiceMethodVisitor.kt
@@ -29,6 +29,9 @@ class ServiceMethodVisitor : KSEmptyVisitor<Unit, ServiceMethodDefinition>() {
     }
 
     override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: Unit): ServiceMethodDefinition {
+        if (function.parameters.size != 1) reportError(function, "Service methods must have exactly one parameter")
+        if (function.returnType == null) reportError(function, "Service methods must declare a return type.")
+
         var type: MethodDescriptor.MethodType = MethodDescriptor.MethodType.UNKNOWN
         var methodName = function.simpleName.asString()
 

--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/ServiceVisitor.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/ServiceVisitor.kt
@@ -3,19 +3,28 @@ package com.github.darvld.krpc.compiler
 import com.github.darvld.krpc.Service
 import com.github.darvld.krpc.compiler.model.ServiceDefinition
 import com.google.devtools.ksp.getDeclaredFunctions
+import com.google.devtools.ksp.symbol.ClassKind.INTERFACE
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.validate
 import com.google.devtools.ksp.visitor.KSDefaultVisitor
 
 class ServiceVisitor : KSDefaultVisitor<Unit, ServiceDefinition>() {
     private val methodVisitor = ServiceMethodVisitor()
 
+    private fun reportError(inClass: KSClassDeclaration, message: String) {
+        throw IllegalStateException("Error while processing service definition ${inClass.qualifiedName?.asString()}: $message")
+    }
+
     override fun defaultHandler(node: KSNode, data: Unit): ServiceDefinition {
         throw IllegalStateException("Service visitor can only visit service definition interfaces")
     }
 
     override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit): ServiceDefinition {
+        if (classDeclaration.classKind != INTERFACE && Modifier.ABSTRACT !in classDeclaration.modifiers)
+            reportError(classDeclaration, "Service definitions must be interfaces or abstract classes")
+
         // The annotation arguments contain the names for the service, the provider and the client (if specified)
         val annotationArgs = classDeclaration.annotations.find {
             it.shortName.getShortName() == Service::class.simpleName

--- a/playground/src/main/kotlin/com/example/GpsService.kt
+++ b/playground/src/main/kotlin/com/example/GpsService.kt
@@ -5,6 +5,6 @@ import com.github.darvld.krpc.UnaryCall
 
 @Service
 interface GpsService {
-    @UnaryCall
+    @UnaryCall("customName")
     suspend fun doSomething(message: String): Int
 }


### PR DESCRIPTION
`ServiceVisitor` and `ServiceMethodVisitor` now validate declarations attending to required signatures: interfaces or abstract classes are required for service definitions and suspend nature of service methods is checked to match the required signature.