### PR TITLE
Adds more flexible declarations.

### DIFF
--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/ErrorReporting.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/ErrorReporting.kt
@@ -1,0 +1,21 @@
+package com.github.darvld.krpc.compiler
+
+import com.github.darvld.krpc.compiler.model.ServiceMethodDefinition
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+
+/**Throws [IllegalStateException] with the given [message] and signalling [inFunction] as the source of the problem.*/
+fun reportError(inFunction: KSFunctionDeclaration, message: String): Nothing {
+    throw IllegalStateException("Error while processing service method ${inFunction.qualifiedName?.asString()}: $message")
+}
+
+
+/**Throws [IllegalStateException] with the given [message] and signalling [inMethod] as the source of the problem.*/
+fun reportError(inMethod: ServiceMethodDefinition, message: String): Nothing {
+    throw IllegalStateException("Error while processing service method ${inMethod.methodName}: $message")
+}
+
+/**Throws [IllegalStateException] with the given [message] and signalling [inClass] as the source of the problem.*/
+fun reportError(inClass: KSClassDeclaration, message: String) {
+    throw IllegalStateException("Error while processing service definition ${inClass.qualifiedName?.asString()}: $message")
+}

--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/ServiceMethodVisitor.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/ServiceMethodVisitor.kt
@@ -9,6 +9,7 @@ import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.visitor.KSEmptyVisitor
+import com.squareup.kotlinpoet.asClassName
 import io.grpc.MethodDescriptor
 
 /**Function visitor used by [ServiceVisitor] to extract service method definitions from annotated members inside
@@ -41,7 +42,6 @@ class ServiceMethodVisitor : KSEmptyVisitor<String, ServiceMethodDefinition>() {
     override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: String): ServiceMethodDefinition {
         // Signature check
         if (function.parameters.size != 1) reportError(function, "Service methods must have exactly one parameter")
-        if (function.returnType == null) reportError(function, "Service methods must declare a return type.")
 
         var type: MethodDescriptor.MethodType = MethodDescriptor.MethodType.UNKNOWN
         var methodName = function.simpleName.asString()
@@ -80,7 +80,7 @@ class ServiceMethodVisitor : KSEmptyVisitor<String, ServiceMethodDefinition>() {
         return ServiceMethodDefinition(
             declaredName = function.simpleName.getShortName(),
             methodName = "$data/$methodName",
-            returnType = function.returnType,
+            returnType = function.returnType?.resolve()?.asClassName() ?: Unit::class.asClassName(),
             request = function.parameters.singleOrNull()
                 ?: reportError(function, "Service methods must have a single parameter."),
             methodType = type

--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/ServiceMethodVisitor.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/ServiceMethodVisitor.kt
@@ -7,6 +7,7 @@ import com.github.darvld.krpc.UnaryCall
 import com.github.darvld.krpc.compiler.model.ServiceMethodDefinition
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.visitor.KSEmptyVisitor
 import com.squareup.kotlinpoet.ClassName
@@ -31,14 +32,28 @@ class ServiceMethodVisitor : KSEmptyVisitor<String, ServiceMethodDefinition>() {
             reportError(this, "Unary and ClientStream rpc methods must be marked with the suspend modifier.")
     }
 
-    /**Extracts the Flow return type of this function and returns the type parameter for that flow.*/
-    private fun KSFunctionDeclaration.extractFlowType(): ClassName {
-        return returnType?.resolve()?.let {
-            if (it.declaration.simpleName.asString() != "Flow")
-                reportError(this, "ServerStream and BidiStream rpc methods must return Flow.")
+    /**Extracts the type parameter for this type reference if it is a flow, returns null otherwise.*/
+    private fun KSTypeReference.extractFlowType(): ClassName? {
+        return resolve().let {
+            if (it.declaration.simpleName.asString() != "Flow") return null
 
             it.arguments.single().type!!.resolve().asClassName()
-        } ?: reportError(this, "ServerStream and BidiStream rpc methods must declare a return type.")
+        }
+    }
+
+    private fun KSFunctionDeclaration.extractRequest(flow: Boolean): Pair<String, ClassName> {
+        return if (flow) {
+            parameters.singleOrNull()?.let {
+                it.name!!.asString() to (it.type.extractFlowType() ?: return@let null)
+            } ?: reportError(
+                this,
+                "ClientStream and BidiStream methods must have a single Flow parameter"
+            )
+        } else {
+            parameters.singleOrNull()?.let {
+                it.name!!.asString() to it.type.resolve().asClassName()
+            } ?: "unit" to UnitClassName
+        }
     }
 
     override fun defaultHandler(node: KSNode, data: String): ServiceMethodDefinition {
@@ -52,32 +67,41 @@ class ServiceMethodVisitor : KSEmptyVisitor<String, ServiceMethodDefinition>() {
         var type: MethodDescriptor.MethodType = MethodDescriptor.MethodType.UNKNOWN
         var methodName = function.simpleName.asString()
         var returnType: ClassName? = null
+        var request: Pair<String, ClassName>? = null
 
         for (annotation in function.annotations) {
-            type = when (annotation.shortName.getShortName()) {
+            when (annotation.shortName.getShortName()) {
                 UnaryCall::class.simpleName -> {
                     function.requireSuspending(true)
-                    returnType = function.returnType?.resolve()?.asClassName() ?: Unit::class.asClassName()
 
-                    MethodDescriptor.MethodType.UNARY
+                    returnType = function.returnType?.resolve()?.asClassName() ?: UnitClassName
+                    request = function.extractRequest(false)
+                    type = MethodDescriptor.MethodType.UNARY
                 }
                 ClientStream::class.simpleName -> {
                     function.requireSuspending(true)
-                    returnType = function.returnType?.resolve()?.asClassName() ?: Unit::class.asClassName()
 
-                    MethodDescriptor.MethodType.CLIENT_STREAMING
+                    returnType = function.returnType?.resolve()?.asClassName() ?: Unit::class.asClassName()
+                    request = function.extractRequest(true)
+                    type = MethodDescriptor.MethodType.CLIENT_STREAMING
                 }
                 ServerStream::class.simpleName -> {
                     function.requireSuspending(false)
-                    returnType = function.extractFlowType()
 
-                    MethodDescriptor.MethodType.SERVER_STREAMING
+                    returnType = function.returnType?.extractFlowType()
+                        ?: reportError(function, "ServerStream and BidiStream rpc methods must return Flow.")
+
+                    request = function.extractRequest(false)
+                    type = MethodDescriptor.MethodType.SERVER_STREAMING
                 }
                 BidiStream::class.simpleName -> {
                     function.requireSuspending(false)
-                    returnType = function.extractFlowType()
 
-                    MethodDescriptor.MethodType.BIDI_STREAMING
+                    returnType = function.returnType?.extractFlowType()
+                        ?: reportError(function, "ServerStream and BidiStream rpc methods must return Flow.")
+
+                    request = function.extractRequest(true)
+                    type = MethodDescriptor.MethodType.BIDI_STREAMING
                 }
                 else -> continue
             }
@@ -93,13 +117,13 @@ class ServiceMethodVisitor : KSEmptyVisitor<String, ServiceMethodDefinition>() {
             reportError(function, "Method declarations inside @Service interfaces must provide a call type annotation.")
 
         if (returnType == null) reportError(function, "Unsupported return type")
+        if (request == null) reportError(function, "Unsupported argument type")
 
         return ServiceMethodDefinition(
             declaredName = function.simpleName.getShortName(),
             methodName = "$data/$methodName",
             returnType = returnType,
-            request = function.parameters.singleOrNull()
-                ?: reportError(function, "Service methods must have a single parameter."),
+            request = request,
             methodType = type
         )
     }

--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/ServiceVisitor.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/ServiceVisitor.kt
@@ -20,10 +20,6 @@ class ServiceVisitor : KSDefaultVisitor<Unit, ServiceDefinition>() {
     /**Function visitor used to extract service method definitions from members.*/
     private val methodVisitor = ServiceMethodVisitor()
 
-    /**Throws [IllegalStateException] with the given [message] and signalling [inClass] as the source of the problem.*/
-    private fun reportError(inClass: KSClassDeclaration, message: String) {
-        throw IllegalStateException("Error while processing service definition ${inClass.qualifiedName?.asString()}: $message")
-    }
 
     override fun defaultHandler(node: KSNode, data: Unit): ServiceDefinition {
         throw IllegalStateException("Service visitor can only visit service definition interfaces")

--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/Utils.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/Utils.kt
@@ -2,9 +2,12 @@ package com.github.darvld.krpc.compiler
 
 import com.google.devtools.ksp.symbol.KSType
 import com.squareup.kotlinpoet.*
+import kotlinx.coroutines.flow.Flow
 import java.io.OutputStream
 import javax.annotation.processing.Generated
 
+val UnitClassName = Unit::class.asClassName()
+val FlowClassName = Flow::class.asClassName()
 
 private val generatedAnnotationSpec = AnnotationSpec.builder(Generated::class)
     .addMember("\"com.github.darvld.krpc\"")

--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/generators/GenerateDescriptor.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/generators/GenerateDescriptor.kt
@@ -83,7 +83,7 @@ private fun TypeSpec.Builder.addMarshaller(typeName: ClassName): PropertySpec {
 private fun TypeSpec.Builder.addServiceMethodDescriptor(
     definition: ServiceMethodDefinition
 ) {
-    val requestType = definition.request.type.resolve().asClassName()
+    val requestType = definition.request.second
     val responseType = definition.returnType
 
     val type = MethodDescriptor::class.asTypeName()

--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/generators/GenerateDescriptor.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/generators/GenerateDescriptor.kt
@@ -84,7 +84,7 @@ private fun TypeSpec.Builder.addServiceMethodDescriptor(
     definition: ServiceMethodDefinition
 ) {
     val requestType = definition.request.type.resolve().asClassName()
-    val responseType = (definition.returnType!!.resolve()).asClassName()
+    val responseType = definition.returnType
 
     val type = MethodDescriptor::class.asTypeName()
         .parameterizedBy(requestType, responseType)

--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/generators/GenerateServer.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/generators/GenerateServer.kt
@@ -23,6 +23,7 @@ addMethod(
                implementation = ::%L
             )
         )
+        
 """
 
 /**Code block body used for the server descriptor builder.*/

--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/model/ServiceMethodDefinition.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/model/ServiceMethodDefinition.kt
@@ -1,7 +1,7 @@
 package com.github.darvld.krpc.compiler.model
 
-import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.symbol.KSValueParameter
+import com.squareup.kotlinpoet.ClassName
 import io.grpc.MethodDescriptor
 
 /**Model class used by [ServiceProcessor][com.github.darvld.krpc.compiler.ServiceProcessor] to store information
@@ -14,9 +14,11 @@ data class ServiceMethodDefinition(
     /**The "official" GRPC name of this method.*/
     val methodName: String,
     /**Return type of the method.*/
-    val returnType: KSTypeReference?,
+    val returnType: ClassName,
     /**The request parameter, required by GRPC.*/
     val request: KSValueParameter,
     /**The type of rpc call this method represents.*/
     val methodType: MethodDescriptor.MethodType
-)
+) {
+    val returnsUnit: Boolean get() = returnType.simpleName == "Unit"
+}

--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/model/ServiceMethodDefinition.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/model/ServiceMethodDefinition.kt
@@ -16,7 +16,7 @@ data class ServiceMethodDefinition(
     /**Return type of the method.*/
     val returnType: ClassName,
     /**The request parameter, required by GRPC.*/
-    val request: KSValueParameter,
+    val request: Pair<String, ClassName>,
     /**The type of rpc call this method represents.*/
     val methodType: MethodDescriptor.MethodType
 ) {

--- a/krpc-runtime/src/main/kotlin/com.github.darvld.krpc/SerializationProvider.kt
+++ b/krpc-runtime/src/main/kotlin/com.github.darvld.krpc/SerializationProvider.kt
@@ -2,7 +2,15 @@ package com.github.darvld.krpc
 
 import io.grpc.MethodDescriptor
 import kotlinx.serialization.KSerializer
+import java.io.InputStream
 
 interface SerializationProvider {
     fun <T> marshallerFor(serializer: KSerializer<T>): MethodDescriptor.Marshaller<T>
+
+    /**A noop marshaller used for the [Unit] type.*/
+    object UnitSerializer : MethodDescriptor.Marshaller<Unit> {
+        override fun parse(stream: InputStream?) = Unit
+
+        override fun stream(value: Unit?): InputStream = InputStream.nullInputStream()
+    }
 }

--- a/playground/src/main/kotlin/com/example/GpsService.kt
+++ b/playground/src/main/kotlin/com/example/GpsService.kt
@@ -1,7 +1,9 @@
 package com.example
 
+import com.github.darvld.krpc.ServerStream
 import com.github.darvld.krpc.Service
 import com.github.darvld.krpc.UnaryCall
+import kotlinx.coroutines.flow.Flow
 
 @Service
 interface GpsService {
@@ -10,4 +12,7 @@ interface GpsService {
 
     @UnaryCall
     suspend fun fireAndForget(message: String)
+
+    @ServerStream
+    fun getStream(message: String): Flow<String>
 }

--- a/playground/src/main/kotlin/com/example/GpsService.kt
+++ b/playground/src/main/kotlin/com/example/GpsService.kt
@@ -1,8 +1,6 @@
 package com.example
 
-import com.github.darvld.krpc.ServerStream
-import com.github.darvld.krpc.Service
-import com.github.darvld.krpc.UnaryCall
+import com.github.darvld.krpc.*
 import kotlinx.coroutines.flow.Flow
 
 @Service
@@ -13,6 +11,12 @@ interface GpsService {
     @UnaryCall
     suspend fun fireAndForget(message: String)
 
+    @ClientStream
+    suspend fun sendStream(messages: Flow<String>)
+
     @ServerStream
     fun getStream(message: String): Flow<String>
+
+    @BidiStream
+    fun sendAndReceive(messages: Flow<String>): Flow<String>
 }

--- a/playground/src/main/kotlin/com/example/GpsService.kt
+++ b/playground/src/main/kotlin/com/example/GpsService.kt
@@ -7,4 +7,7 @@ import com.github.darvld.krpc.UnaryCall
 interface GpsService {
     @UnaryCall("customName")
     suspend fun doSomething(message: String): Int
+
+    @UnaryCall
+    suspend fun fireAndForget(message: String)
 }


### PR DESCRIPTION
- Return type for `@UnaryCall` and `@ClientStream` methods can be omitted.
- Argument can be omitted for `@UnaryCall` and `@ServerStream` methods.
- Fixed wrong generation of streaming methods.