### PR TITLE
Generics support

### DIFF
--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/TypeUtils.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/TypeUtils.kt
@@ -1,6 +1,5 @@
 package com.github.darvld.krpc.compiler
 
-import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeReference
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -9,28 +8,19 @@ import kotlinx.coroutines.flow.Flow
 internal val UnitClassName by lazy { Unit::class.asClassName() }
 internal val FlowClassName by lazy { Flow::class.asClassName() }
 
-/**Resolves this type reference and constructs a [ClassName] from the type's package name and simple name.
- *
- *  This extension does not handle generics, use [resolveAsParameterizedName] instead.*/
-internal fun KSTypeReference.resolveAsClassName(): ClassName {
-    return resolve().declaration.run {
-        ClassName(packageName.asString(), simpleName.asString())
-    }
-}
-
 /**Resolves this type reference and attempts construct a [ParameterizedTypeName].*/
 internal fun KSTypeReference.resolveAsParameterizedName(): ParameterizedTypeName? {
-    return resolve().asTypeName() as? ParameterizedTypeName
+    return resolveAsTypeName() as? ParameterizedTypeName
 }
 
-/**Maps this ksp [KSType] into a kotlinPoet [TypeName].
+/**Resolves this ksp [KSTypeReference] as a kotlinPoet [TypeName].
  *
  * For non-generic types, this method returns a simple [ClassName]. For generics, it recursively resolves
  * type arguments.*/
-internal fun KSType.asTypeName(): TypeName {
+internal fun KSTypeReference.resolveAsTypeName(): TypeName = with(resolve()) {
     val baseName = ClassName(declaration.packageName.asString(), declaration.simpleName.asString())
 
     if (arguments.isEmpty()) return baseName
 
-    return baseName.parameterizedBy(arguments.map { it.type?.resolve()?.asTypeName() ?: STAR })
+    return baseName.parameterizedBy(arguments.map { it.type?.resolveAsTypeName() ?: STAR })
 }

--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/model/ClientStreamMethod.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/model/ClientStreamMethod.kt
@@ -1,9 +1,8 @@
 package com.github.darvld.krpc.compiler.model
 
 import com.github.darvld.krpc.ClientStream
+import com.github.darvld.krpc.compiler.*
 import com.github.darvld.krpc.compiler.UnitClassName
-import com.github.darvld.krpc.compiler.reportError
-import com.github.darvld.krpc.compiler.resolveAsClassName
 import com.github.darvld.krpc.compiler.resolveAsParameterizedName
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
@@ -34,7 +33,7 @@ class ClientStreamMethod(
             declaration.requireSuspending(true, "ClientStream rpc methods must be marked with 'suspend' modifier.")
 
             val methodName = declaration.extractMethodName(annotation)
-            val responseType = declaration.returnType?.resolveAsClassName() ?: UnitClassName
+            val responseType = declaration.returnType?.resolveAsTypeName() ?: UnitClassName
 
             val (requestName, requestType) = declaration.extractRequestInfo { reference ->
                 // Resolve the request type, which should be a Flow<T>, and extract the 'T' type name.

--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/model/ServerStreamMethod.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/model/ServerStreamMethod.kt
@@ -1,9 +1,8 @@
 package com.github.darvld.krpc.compiler.model
 
 import com.github.darvld.krpc.ServerStream
+import com.github.darvld.krpc.compiler.*
 import com.github.darvld.krpc.compiler.UnitClassName
-import com.github.darvld.krpc.compiler.reportError
-import com.github.darvld.krpc.compiler.resolveAsClassName
 import com.github.darvld.krpc.compiler.resolveAsParameterizedName
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
@@ -44,7 +43,7 @@ class ServerStreamMethod(
                     message = "ServerStream rpc methods must return a Flow of a serializable type."
                 )
 
-            val (requestName, requestType) = declaration.extractRequestInfo { it.resolveAsClassName() }
+            val (requestName, requestType) = declaration.extractRequestInfo { it.resolveAsTypeName() }
                 ?: "unit" to UnitClassName
 
             return ServerStreamMethod(

--- a/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/model/UnaryMethod.kt
+++ b/krpc-compiler/src/main/kotlin/com/github/darvld/krpc/compiler/model/UnaryMethod.kt
@@ -2,7 +2,7 @@ package com.github.darvld.krpc.compiler.model
 
 import com.github.darvld.krpc.UnaryCall
 import com.github.darvld.krpc.compiler.UnitClassName
-import com.github.darvld.krpc.compiler.resolveAsClassName
+import com.github.darvld.krpc.compiler.resolveAsTypeName
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.squareup.kotlinpoet.TypeName
@@ -32,9 +32,9 @@ class UnaryMethod(
             declaration.requireSuspending(true, "UnaryCall rpc methods must be marked with 'suspend' modifier.")
 
             val methodName = declaration.extractMethodName(annotation)
-            val returnType = declaration.returnType?.resolveAsClassName() ?: UnitClassName
+            val returnType = declaration.returnType?.resolveAsTypeName() ?: UnitClassName
 
-            val (requestName, requestType) = declaration.extractRequestInfo { it.resolveAsClassName() }
+            val (requestName, requestType) = declaration.extractRequestInfo { it.resolveAsTypeName() }
                 ?: "unit" to UnitClassName
 
             return UnaryMethod(

--- a/krpc-compiler/src/test/kotlin/com/github/darvld/krpc/compiler/ServiceMethodVisitorTest.kt
+++ b/krpc-compiler/src/test/kotlin/com/github/darvld/krpc/compiler/ServiceMethodVisitorTest.kt
@@ -1,13 +1,7 @@
 package com.github.darvld.krpc.compiler
 
-import com.github.darvld.krpc.compiler.generators.CodeGenerationTest.Companion.IntClassName
-import com.github.darvld.krpc.compiler.generators.CodeGenerationTest.Companion.ListClassName
-import com.github.darvld.krpc.compiler.generators.CodeGenerationTest.Companion.StringClassName
 import com.github.darvld.krpc.compiler.model.*
-import com.github.darvld.krpc.compiler.testing.assertIs
-import com.github.darvld.krpc.compiler.testing.shouldBe
-import com.github.darvld.krpc.compiler.testing.shouldContain
-import com.github.darvld.krpc.compiler.testing.whenCompiling
+import com.github.darvld.krpc.compiler.testing.*
 import com.google.devtools.ksp.getFunctionDeclarationsByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
@@ -50,8 +44,8 @@ class ServiceMethodVisitorTest {
         methodName: String,
         type: MethodDescriptor.MethodType,
         requestName: String = "request",
-        requestType: TypeName = IntClassName,
-        responseType: TypeName = StringClassName,
+        requestType: TypeName = ClassNames.Int,
+        responseType: TypeName = ClassNames.String,
         suspending: Boolean,
         @Language("kotlin") imports: String = "",
         @Language("kotlin") definitionBlock: String
@@ -242,7 +236,7 @@ class ServiceMethodVisitorTest {
             declaredName = "unary",
             methodName = "unaryCall",
             type = UNARY,
-            requestType = ListClassName.parameterizedBy(IntClassName),
+            requestType = ClassNames.List.parameterizedBy(ClassNames.Int),
             suspending = true,
             imports = "import kotlin.collections.List",
             definitionBlock = """
@@ -257,7 +251,7 @@ class ServiceMethodVisitorTest {
             declaredName = "unary",
             methodName = "unaryCall",
             type = UNARY,
-            responseType = ListClassName.parameterizedBy(StringClassName),
+            responseType = ClassNames.List.parameterizedBy(ClassNames.String),
             suspending = true,
             imports = "import kotlin.collections.List",
             definitionBlock = """
@@ -273,7 +267,7 @@ class ServiceMethodVisitorTest {
             methodName = "serverStream",
             type = SERVER_STREAMING,
             suspending = false,
-            responseType = StringClassName,
+            responseType = ClassNames.String,
             imports = "import kotlinx.coroutines.flow.Flow",
             definitionBlock = """
             @ServerStream("serverStream")
@@ -290,7 +284,7 @@ class ServiceMethodVisitorTest {
             requestName = "unit",
             requestType = UnitClassName,
             suspending = false,
-            responseType = StringClassName,
+            responseType = ClassNames.String,
             imports = "import kotlinx.coroutines.flow.Flow",
             definitionBlock = """
             @ServerStream("serverStream")
@@ -305,7 +299,7 @@ class ServiceMethodVisitorTest {
             methodName = "serverStream",
             type = SERVER_STREAMING,
             suspending = false,
-            responseType = ListClassName.parameterizedBy(StringClassName),
+            responseType = ClassNames.List.parameterizedBy(ClassNames.String),
             imports = """
             import kotlin.collections.List
             import kotlinx.coroutines.flow.Flow
@@ -323,7 +317,7 @@ class ServiceMethodVisitorTest {
             methodName = "clientStream",
             type = CLIENT_STREAMING,
             suspending = true,
-            requestType = IntClassName,
+            requestType = ClassNames.Int,
             imports = "import kotlinx.coroutines.flow.Flow",
             definitionBlock = """
             @ClientStream("clientStream")
@@ -338,7 +332,7 @@ class ServiceMethodVisitorTest {
             methodName = "clientStream",
             type = CLIENT_STREAMING,
             suspending = true,
-            requestType = ListClassName.parameterizedBy(IntClassName),
+            requestType = ClassNames.List.parameterizedBy(ClassNames.Int),
             imports = """
             import kotlin.collections.List
             import kotlinx.coroutines.flow.Flow
@@ -371,8 +365,8 @@ class ServiceMethodVisitorTest {
         methodName = "bidiStream",
         type = BIDI_STREAMING,
         suspending = false,
-        requestType = IntClassName,
-        responseType = StringClassName,
+        requestType = ClassNames.Int,
+        responseType = ClassNames.String,
         imports = "import kotlinx.coroutines.flow.Flow",
         definitionBlock = """
         @BidiStream("bidiStream")
@@ -386,8 +380,8 @@ class ServiceMethodVisitorTest {
         methodName = "bidiStream",
         type = BIDI_STREAMING,
         suspending = false,
-        requestType = ListClassName.parameterizedBy(IntClassName),
-        responseType = ListClassName.parameterizedBy(StringClassName),
+        requestType = ClassNames.List.parameterizedBy(ClassNames.Int),
+        responseType = ClassNames.List.parameterizedBy(ClassNames.String),
         imports = """
         import kotlin.collections.List
         import kotlinx.coroutines.flow.Flow

--- a/krpc-compiler/src/test/kotlin/com/github/darvld/krpc/compiler/generators/CodeGenerationTest.kt
+++ b/krpc-compiler/src/test/kotlin/com/github/darvld/krpc/compiler/generators/CodeGenerationTest.kt
@@ -5,9 +5,9 @@ import com.github.darvld.krpc.compiler.model.BidiStreamMethod
 import com.github.darvld.krpc.compiler.model.ServiceDefinition
 import com.github.darvld.krpc.compiler.model.ServiceMethodDefinition
 import com.github.darvld.krpc.compiler.model.UnaryMethod
+import com.github.darvld.krpc.compiler.testing.ClassNames
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
-import com.squareup.kotlinpoet.asClassName
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import java.io.File
@@ -32,9 +32,7 @@ abstract class CodeGenerationTest {
     }
 
     companion object {
-        val ListClassName by lazy { List::class.asClassName() }
-        val IntClassName by lazy { Int::class.asClassName() }
-        val StringClassName by lazy { String::class.asClassName() }
+
 
         fun serviceDefinition(
             declaredName: String = "TestService",
@@ -56,8 +54,8 @@ abstract class CodeGenerationTest {
             declaredName: String = "unary",
             methodName: String = "${declaredName}Test",
             requestName: String = "request",
-            requestType: TypeName = IntClassName,
-            returnType: TypeName = StringClassName
+            requestType: TypeName = ClassNames.Int,
+            returnType: TypeName = ClassNames.String
         ): UnaryMethod = UnaryMethod(
             declaredName,
             methodName,
@@ -70,8 +68,8 @@ abstract class CodeGenerationTest {
             declaredName: String = "bidiStream",
             methodName: String = "${declaredName}Test",
             requestName: String = "request",
-            requestType: TypeName = IntClassName,
-            returnType: TypeName = StringClassName
+            requestType: TypeName = ClassNames.Int,
+            returnType: TypeName = ClassNames.String
         ) = BidiStreamMethod(
             declaredName,
             methodName,

--- a/krpc-compiler/src/test/kotlin/com/github/darvld/krpc/compiler/generators/CodeGenerationTest.kt
+++ b/krpc-compiler/src/test/kotlin/com/github/darvld/krpc/compiler/generators/CodeGenerationTest.kt
@@ -32,6 +32,7 @@ abstract class CodeGenerationTest {
     }
 
     companion object {
+        val ListClassName by lazy { List::class.asClassName() }
         val IntClassName by lazy { Int::class.asClassName() }
         val StringClassName by lazy { String::class.asClassName() }
 

--- a/krpc-compiler/src/test/kotlin/com/github/darvld/krpc/compiler/generators/DescriptorGenerationTest.kt
+++ b/krpc-compiler/src/test/kotlin/com/github/darvld/krpc/compiler/generators/DescriptorGenerationTest.kt
@@ -3,6 +3,7 @@ package com.github.darvld.krpc.compiler.generators
 import com.github.darvld.krpc.compiler.UnitClassName
 import com.github.darvld.krpc.compiler.testing.ClassNames.Int
 import com.github.darvld.krpc.compiler.testing.ClassNames.List
+import com.github.darvld.krpc.compiler.testing.ClassNames.String
 import com.github.darvld.krpc.compiler.testing.assertContentEquals
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
@@ -217,6 +218,61 @@ class DescriptorGenerationTest : CodeGenerationTest() {
                 .setType(UNARY)
                 .setRequestMarshaller(intMarshaller)
                 .setResponseMarshaller(stringMarshaller)
+                .build()
+
+            }
+            
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `generates unary method descriptor with generic request and response`() {
+        val method = unaryMethod(
+            requestType = List.parameterizedBy(Int),
+            returnType = List.parameterizedBy(String)
+        )
+
+        val service = serviceDefinition(methods = listOf(method))
+
+        val generated = temporaryFolder.newObject("Descriptor") {
+            // Placeholder properties so the marshallers are not generated (already covered by another test)
+            addProperty(PropertySpec.builder("intListMarshaller", Nothing::class).initializer("TODO()").build())
+            addProperty(PropertySpec.builder("stringListMarshaller", Nothing::class).initializer("TODO()").build())
+
+            descriptorGenerator.buildMethodDescriptor(method, service).let(::addProperty)
+        }
+
+        generated.assertContentEquals(
+            """
+            package com.test.generated
+            
+            import io.grpc.MethodDescriptor
+            import io.grpc.MethodDescriptor.MethodType.UNARY
+            import java.lang.Void
+            import javax.`annotation`.processing.Generated
+            import kotlin.Int
+            import kotlin.String
+            import kotlin.collections.List
+            
+            public object Descriptor {
+              public val intListMarshaller: Void = TODO()
+
+              public val stringListMarshaller: Void = TODO()
+
+              /**
+               * Generated gRPC [MethodDescriptor] for the
+               * [TestService.unary][com.test.generated.TestService.unary] method.
+               *
+               * This descriptor is used by generated service components and should not be used in general code.
+               */
+              @Generated("com.github.darvld.krpc")
+              public val unary: MethodDescriptor<List<Int>, List<String>> = MethodDescriptor
+                .newBuilder<List<Int>, List<String>>()
+                .setFullMethodName("TestService/unaryTest")
+                .setType(UNARY)
+                .setRequestMarshaller(intListMarshaller)
+                .setResponseMarshaller(stringListMarshaller)
                 .build()
 
             }

--- a/krpc-compiler/src/test/kotlin/com/github/darvld/krpc/compiler/generators/DescriptorGenerationTest.kt
+++ b/krpc-compiler/src/test/kotlin/com/github/darvld/krpc/compiler/generators/DescriptorGenerationTest.kt
@@ -55,7 +55,7 @@ class DescriptorGenerationTest : CodeGenerationTest() {
     @Test
     fun `generates marshaller for simple type`() {
         val generated = temporaryFolder.newObject("Marshallers") {
-            addMarshaller(Int::class.asTypeName())
+            addMarshaller(Int)
         }
 
         generated.assertContentEquals(

--- a/krpc-compiler/src/test/kotlin/com/github/darvld/krpc/compiler/testing/ClassNames.kt
+++ b/krpc-compiler/src/test/kotlin/com/github/darvld/krpc/compiler/testing/ClassNames.kt
@@ -1,0 +1,9 @@
+package com.github.darvld.krpc.compiler.testing
+
+import com.squareup.kotlinpoet.asClassName
+
+object ClassNames {
+    val List by lazy { List::class.asClassName() }
+    val Int by lazy { Int::class.asClassName() }
+    val String by lazy { String::class.asClassName() }
+}

--- a/sample/src/main/kotlin/com/example/GpsService.kt
+++ b/sample/src/main/kotlin/com/example/GpsService.kt
@@ -9,6 +9,10 @@ import kotlinx.coroutines.flow.Flow
 @Service
 interface GpsService {
 
+    /**Returns a list of all the vehicles currently tracked by this service.*/
+    @UnaryCall
+    suspend fun listVehicles(): List<Vehicle>
+
     /**Returns the last known location of a given [vehicle].*/
     @UnaryCall
     suspend fun locationForVehicle(vehicle: Vehicle): Location

--- a/sample/src/main/kotlin/com/example/Simulation.kt
+++ b/sample/src/main/kotlin/com/example/Simulation.kt
@@ -1,6 +1,8 @@
 package com.example
 
+import com.example.model.Location
 import kotlinx.coroutines.delay
+import kotlin.random.Random
 
 /**Helper object used to simulate some execution behaviours.*/
 object Simulation {
@@ -20,4 +22,11 @@ object Simulation {
 
     /**Causes a short delay (~5 seconds), or none if the current run is part of a CI build.*/
     suspend inline fun longDelay() = adjustedDelay(5_000)
+
+    /**Returns a randomly constructed [Location].
+     *
+     * Note that the returned location could point anywhere, in the middle of the ocean for example. Don't know, don't care*/
+    fun randomLocation(): Location {
+        return Location(Random.nextDouble(-180.0, 180.0), Random.nextDouble(-180.0, 180.0))
+    }
 }

--- a/sample/src/main/kotlin/com/example/backend/GpsServer.kt
+++ b/sample/src/main/kotlin/com/example/backend/GpsServer.kt
@@ -1,12 +1,13 @@
 package com.example.backend
 
 import com.example.GpsServiceProvider
-import com.example.Simulation
+import com.example.Simulation.moderateDelay
+import com.example.Simulation.randomLocation
+import com.example.Simulation.shortDelay
 import com.example.model.Location
 import com.example.model.Vehicle
 import com.github.darvld.krpc.SerializationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlin.random.Random
 
@@ -15,13 +16,16 @@ class GpsServer(
     serializationProvider: SerializationProvider,
 ) : GpsServiceProvider(serializationProvider) {
 
-    private fun randomLocation(): Location {
-        return Location(Random.nextDouble(-180.0, 180.0), Random.nextDouble(-180.0, 180.0))
+    override suspend fun listVehicles(): List<Vehicle> {
+        // Return a list of randomly generated vehicles
+        return List(5) {
+            Vehicle(Random.nextLong(1000, 9999), "SampleVehicle-SV$it")
+        }
     }
 
     override suspend fun locationForVehicle(vehicle: Vehicle): Location {
         // Pretend we're doing something here
-        Simulation.shortDelay()
+        shortDelay()
         return randomLocation()
     }
 
@@ -32,7 +36,7 @@ class GpsServer(
         // Endlessly track this vehicle until the rpc is cancelled
         while (true) {
             // Add delay between location updates
-            Simulation.moderateDelay()
+            moderateDelay()
             // Move it a little (~10m) in a straight line
             emit(location.copy(latitude = location.latitude + 0.001).also { location = it })
         }
@@ -45,7 +49,7 @@ class GpsServer(
         route.collect {
             println("[Server] Received $it from route stream #$routeCode")
             // Pretend we did something useful with the location
-            Simulation.shortDelay()
+            shortDelay()
         }
         return true
     }


### PR DESCRIPTION
Add support for generic types in method requests and responses (as long as they're serializable). Closes #12.